### PR TITLE
Technic Launcher OSX

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, faster speed, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?wabty03q7t3t8fv.
+This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, faster speed, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?oa10anyi00htm1h.

--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, should be faster, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?wabty03q7t3t8fv.
+This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, faster speed, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?wabty03q7t3t8fv.

--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-Source for my Technic launcher app. Please let me know if i can improve my code somehow. Thanks :) Compile with AppleScript.
+This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, should be faster, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?wabty03q7t3t8fv.

--- a/README
+++ b/README
@@ -1,1 +1,1 @@
-This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, faster speed, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?oa10anyi00htm1h.
+This is the new and improved Technic Launcher for Mac OS-X. Changes include offline support, a moved jar, smaller size, faster speed, and the fix for the "Hello" bug. Download the compiled version from http://www.mediafire.com/?oa10anyi00htm1h. Be sure to compile with AppleScript Editor, not Automator.

--- a/Technic_Launcher_Source.txt
+++ b/Technic_Launcher_Source.txt
@@ -1,1 +1,65 @@
-on trim_line(this_text, trim_chars, trim_indicator)	-- 0 = beginning, 1 = end, 2 = both	set x to the length of the trim_chars	-- TRIM BEGINNING	if the trim_indicator is in {0, 2} then		repeat while this_text begins with the trim_chars			try				set this_text to characters (x + 1) thru -1 of this_text as string			on error				-- the text contains nothing but the trim characters				return ""			end try		end repeat	end if	-- TRIM ENDING	if the trim_indicator is in {1, 2} then		repeat while this_text ends with the trim_chars			try				set this_text to characters 1 thru -(x + 1) of this_text as string			on error				-- the text contains nothing but the trim characters				return ""			end try		end repeat	end if	return this_textend trim_lineon run	set FilePath to path to me	set FilePath to POSIX path of FilePath	set this_text to FilePath	trim_line(this_text, "Test.scpt", 1)	set FilePath to result	set launcher to "cd " & FilePath & "Contents/Resources/launcher/"	do shell script "curl http://mirror.technicpack.net/files/technic-launcher-latest.jar >> " & FilePath & "/Contents/Resources/temp/" & "technic-launcher-latest.jar"	try		do shell script "cp -n -r " & FilePath & "Contents/Resources/temp/technic-launcher-latest.jar " & FilePath & "Contents/Resources/launcher/technic-launcher-latest.jar"	end try	do shell script "md5 " & FilePath & "Contents/Resources/temp/technic-launcher-latest.jar"	set md5latest to result	trim_line(md5latest, "MD5 (", 0)	set md5latest to result	trim_line(md5latest, FilePath, 0)	set md5latest to result	trim_line(md5latest, "Contents/Resources/temp/technic-launcher-latest.jar) = ", 0)	set md5latest to result	do shell script "md5 " & FilePath & "Contents/Resources/launcher/technic-launcher-latest.jar"	set md5current to result	trim_line(md5current, "MD5 (", 0)	set md5current to result	trim_line(md5current, FilePath, 0)	set md5current to result	trim_line(md5current, "Contents/Resources/Launcher/technic-launcher-latest.jar) = ", 0)	set md5current to result	if md5latest is not md5current then		set answer to button returned of ¬			(display dialog ¬				"A new client update as found! Update?" with title ¬				¬					"New Update!" buttons {"Not Now", "Update"} ¬				default button 2)		if answer is "Update" then			do shell script "rm " & FilePath & "Contents/Resources/launcher/technic-launcher-latest.jar"			try				do shell script "cp -r " & FilePath & "Contents/Resources/temp/technic-launcher-latest.jar " & FilePath & "Contents/Resources/launcher/technic-launcher-latest.jar"			end try						do shell script "rm " & FilePath & "Contents/Resources/temp/technic-launcher-latest.jar"			display alert "Update Successful!"			do shell script launcher & ";java -jar technic-launcher-latest.jar"		end if		if answer is "Not Now" then			do shell script "rm " & FilePath & "Contents/Resources/temp/technic-launcher-latest.jar"			do shell script launcher & ";java -jar technic-launcher-latest.jar"		end if	end if	if md5latest is md5current then		do shell script "rm " & FilePath & "Contents/Resources/temp/technic-launcher-latest.jar"		do shell script launcher & ";java -jar technic-launcher-latest.jar"	end if	(md5latest is md5current) & (md5latest is not md5current)end run
+on trim_line(this_text, trim_chars)
+	set x to the length of the trim_chars
+	repeat while this_text begins with the trim_chars
+		try
+			set this_text to characters (x + 1) thru -1 of this_text as string
+		on error
+			return ""
+		end try
+	end repeat
+	return this_text
+end trim_line
+on run
+	do shell script "mkdir -p ~/Library/Application\\ Support/techniclauncher/temp; touch ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar; rm -rf ~/Library/Application\\ Support/techniclauncher/temp/technic-launcher.jar"
+	try
+		do shell script "curl http://mirror.technicpack.net/Technic/technic-launcher.jar >> ~/Library/Application\\ Support/techniclauncher/temp/technic-launcher.jar"
+	on error
+		display alert "Error: 'Could Not Connect to Technic Site' 
+		Continuing in Offline Mode"
+		try
+			do shell script "java -jar ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar"
+		on error
+			display alert "Error: 'Technic Launcher Not Installed'
+			Terminating"
+			return
+		end try
+		return
+	end try
+	set username to do shell script "whoami"
+	set md5Current to do shell script "md5 ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar"
+	set md5Current to trim_line(md5Current, "MD5 (/Users/" & username & "/Library/Application Support/techniclauncher/technic-launcher.jar) = ")
+	set md5Latest to do shell script "md5 ~/Library/Application\\ Support/techniclauncher/temp/technic-launcher.jar"
+	set md5Latest to trim_line(md5Latest, "MD5 (/Users/" & username & "/Library/Application Support/techniclauncher/temp/technic-launcher.jar) = ")
+	if md5Current is not md5Latest then
+		set answer to button returned of (display dialog "A new launcher update as found! Update?" buttons {"Not Now", "Update"} default button 2)
+		if answer is "Update" then
+			do shell script "rm -rf ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar; cp -r ~/Library/Application\\ Support/techniclauncher/temp/technic-launcher.jar ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar"
+			try
+				do shell script "java -jar ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar"
+			on error
+				display alert "Error: 'Corrupt Download'
+				Terminating"
+				return
+			end try
+		end if
+		if answer is "Not Now" then
+			try
+				do shell script "java -jar ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar"
+			on error
+				display alert "Error: 'Technic Launcher Not Installed'
+				Terminating"
+				return
+			end try
+		end if
+	end if
+	if md5Latest is md5Current then
+		try
+			do shell script "java -jar ~/Library/Application\\ Support/techniclauncher/technic-launcher.jar"
+		on error
+			display alert "Error: 'Corrupt Technic Launcher Install'
+		Terminating"
+			return
+		end try
+	end if
+	do shell script "rm -rf ~/Library/Application\\ Support/techniclauncher/temp/technic-launcher.jar"
+end run


### PR DESCRIPTION
Fixes a bunch of errors and works on the new build of launcher.
Removed the need for trim_indicator
Moved jar to ~/Library/Application Support/techniclauncher
Combined uses of trim_line into one line per file
Added try and on error during download for offline mode
Detects other errors
Moved download link
Probably something I'm forgetting
